### PR TITLE
fix(UX/EditableDynamicListField): Remove 'Options' tab as it can confuses users

### DIFF
--- a/code/editableformfields/EditableDynamicListField.php
+++ b/code/editableformfields/EditableDynamicListField.php
@@ -46,6 +46,7 @@ class EditableDynamicListField extends EditableDropdown {
 
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
+		$fields->removeByName(array('Options'));
 
 		// get a list of data lists to select from
 		$allLists = DataObject::get('DynamicList');
@@ -57,7 +58,7 @@ class EditableDynamicListField extends EditableDropdown {
 			$options = $allLists->map('Title', 'Title');
 		}
 		
-		$fields->addFieldToTab('Root.Main', DropDownField::create('ListTitle', _t('EditableDataListField.DYNAMICLIST_TITLE', 'List Title'), $options));
+		$fields->addFieldToTab('Root.Main', DropdownField::create('ListTitle', _t('EditableDataListField.DYNAMICLIST_TITLE', 'List Title'), $options));
 		return $fields;
 	}
 


### PR DESCRIPTION
Remove 'Options' tab as it can confuses users. (It's unused as the DynamicListField generates its options based on the $ListTitle selected)