### PR TITLE
FIX, the "is used on" functionality seems to only

### DIFF
--- a/code/extensions/DynamicListUDFExtension.php
+++ b/code/extensions/DynamicListUDFExtension.php
@@ -28,7 +28,7 @@ class DynamicListUDFExtension extends DataExtension {
 
 			// This information is stored using a serialised list, therefore we need to iterate through.
 
-			if($field->getSetting('ListTitle') === $this->owner->Title) {
+			if($field->ListTitle === $this->owner->Title) {
 
 				// Make sure there are no duplicates recorded.
 


### PR DESCRIPTION
work sporadically. This function is soon to be deprecated, and directly accessing the property works smoothly with the latest UDF.